### PR TITLE
Fix SketchyBar update placement

### DIFF
--- a/src/player_ui.c
+++ b/src/player_ui.c
@@ -1829,8 +1829,6 @@ int printPlayer(SongData *songdata, double elapsedSeconds, AppSettings *settings
                 fflush(stdout);
         }
 
-        return 0;
-
         /* ──────────────────────────────────────────────────────────────
            Push the current track info into SketchyBar (macOS only), with running time
            ────────────────────────────────────────────────────────────── */
@@ -1876,6 +1874,8 @@ int printPlayer(SongData *songdata, double elapsedSeconds, AppSettings *settings
         system(sb_cmd);
     }
 #endif
+
+        return 0;
 }
 
 void showHelp(void)


### PR DESCRIPTION
## Summary
- move SketchyBar integration before the return statement so it's executed

## Testing
- `make -j$(nproc)` *(fails: `gio/gio.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684f8543f4d0832086b86c49f5f251bc